### PR TITLE
Use LayoutTransform instead RenderTransform

### DIFF
--- a/nUpdate.Administration/Views/NewProject/GenerateKeyPairPage.xaml
+++ b/nUpdate.Administration/Views/NewProject/GenerateKeyPairPage.xaml
@@ -11,9 +11,9 @@
         <TextBlock DockPanel.Dock="Top" FontSize="12pt" Foreground="#003399" Text="Key Pair Generation"/>
         <StackPanel Orientation="Horizontal" VerticalAlignment="Center">
             <loadingIndicators:LoadingIndicator Foreground="LightGray" SpeedRatio="1" Style="{DynamicResource LoadingIndicatorArcsStyle}">
-                <loadingIndicators:LoadingIndicator.RenderTransform>
+                <loadingIndicators:LoadingIndicator.LayoutTransform>
                     <ScaleTransform ScaleX="0.65" ScaleY="0.65" />
-                </loadingIndicators:LoadingIndicator.RenderTransform>
+                </loadingIndicators:LoadingIndicator.LayoutTransform>
             </loadingIndicators:LoadingIndicator>
             <TextBlock Margin="10,0,0,0" VerticalAlignment="Center" Text="Please wait while the keys are generated. This may take some minutes..." TextWrapping="Wrap"/>
         </StackPanel>


### PR DESCRIPTION
You should use LayoutTransform instead RenderTransform to change the size of the LoadingIndicator.

![image](https://user-images.githubusercontent.com/658431/27805776-f4f4ef56-6036-11e7-9912-6bbc1b6054c0.png)
