### PR TITLE
Fix #48 and add two properties to UpdateManager

### DIFF
--- a/nUpdate.Administration/UI/Dialogs/ProjectEditDialog.cs
+++ b/nUpdate.Administration/UI/Dialogs/ProjectEditDialog.cs
@@ -994,9 +994,13 @@ INSERT INTO Application (`ID`, `Name`) VALUES (_APPID, '_APPNAME');";
                     _useStatistics = useStatisticsServerRadioButton.Checked;
                 }));
 
-                bool synchronizeData = Popup.ShowPopup(this, SystemIcons.Question, "Automatically synchronize data?",
-                        "nUpdate Administration may encounter differences between your remote configuration and the local changes that you've made. Should nUpdate Administration try to synchronize these changes or do you want to keep them locally? Choose the latter option, if you just fixed a problem with the data (e.g. a typo due to which nUpdate Administration could not connect to the server).",
-                        PopupButtons.YesNo) == DialogResult.Yes;
+                bool synchronizeData = (bool)Invoke(
+                    new Func<bool>(
+                        () =>
+                            Popup.ShowPopup(this, SystemIcons.Question,
+                            "Automatically synchronize data?",
+                            "nUpdate Administration may encounter differences between your remote configuration and the local changes that you've made. Should nUpdate Administration try to synchronize these changes or do you want to keep them locally? Choose the latter option, if you just fixed a problem with the data (e.g. a typo due to which nUpdate Administration could not connect to the server).",
+                            PopupButtons.YesNo) == DialogResult.Yes));
 
                 if (Project.Name != _name)
                 {
@@ -1058,9 +1062,11 @@ INSERT INTO Application (`ID`, `Name`) VALUES (_APPID, '_APPNAME');";
 
                 if (Project.Path != _localPath)
                 {
-                    if (Popup.ShowPopup(this, SystemIcons.Question, "Automatically move the project file?",
-                            "nUpdate Administration noticed that the path of the local project file has changed. Should nUpdate Administration move it to this new location? Choose \"No\", if the file is already located at the path that you specified.",
-                            PopupButtons.YesNo) == DialogResult.Yes)
+                    if ((bool)Invoke(new Func<bool>(
+                            () =>
+                                Popup.ShowPopup(this, SystemIcons.Question, "Automatically move the project file?",
+                                "nUpdate Administration noticed that the path of the local project file has changed. Should nUpdate Administration move it to this new location? Choose \"No\", if the file is already located at the path that you specified.",
+                                PopupButtons.YesNo) == DialogResult.Yes)))
                     {
                         Invoke(
                             new Action(

--- a/nUpdate.ProvideTAP/Updating/UpdateConfiguration.cs
+++ b/nUpdate.ProvideTAP/Updating/UpdateConfiguration.cs
@@ -23,11 +23,12 @@ namespace nUpdate.Updating
         ///     The optional <see cref="CancellationTokenSource" /> to use for canceling the
         ///     operation.
         /// </param>
+        /// <param name="timeout">The timeout for the download request. In milliseconds. Default 10000.</param>
         /// <returns>Returns an <see cref="IEnumerable{UpdateConfiguration}" /> containing the package configurations.</returns>
         public static Task<IEnumerable<UpdateConfiguration>> DownloadAsync(Uri configFileUri, WebProxy proxy,
-            CancellationTokenSource cancellationTokenSource = null)
+            CancellationTokenSource cancellationTokenSource = null, int timeout = 10000)
         {
-            return DownloadAsync(configFileUri, null, proxy, cancellationTokenSource);
+            return DownloadAsync(configFileUri, null, proxy, cancellationTokenSource, timeout);
         }
 
         /// <summary>
@@ -40,16 +41,17 @@ namespace nUpdate.Updating
         ///     The optional <see cref="CancellationTokenSource" /> to use for canceling the
         ///     operation.
         /// </param>
+        /// <param name="timeout">The timeout for the download request. In milliseconds. Default 10000.</param>
         /// <returns>Returns an <see cref="IEnumerable{UpdateConfiguration}" /> containing the package configurations.</returns>
         public static async Task<IEnumerable<UpdateConfiguration>> DownloadAsync(Uri configFileUri,
             NetworkCredential credentials,
-            WebProxy proxy, CancellationTokenSource cancellationTokenSource = null)
+            WebProxy proxy, CancellationTokenSource cancellationTokenSource = null, int timeout = 10000)
         {
             // Check for SSL and ignore it
             ServicePointManager.ServerCertificateValidationCallback += delegate { return true; };
             
             var request = (HttpWebRequest) WebRequest.Create(configFileUri);
-            request.Timeout = 10000;
+            request.Timeout = timeout;
 
             if (credentials != null)
                 request.Credentials = credentials;

--- a/nUpdate.ProvideTAP/Updating/UpdateManager.cs
+++ b/nUpdate.ProvideTAP/Updating/UpdateManager.cs
@@ -229,6 +229,9 @@ namespace nUpdate.Updating
             double updatePackageSize = 0;
             foreach (var updateConfiguration in PackageConfigurations)
             {
+                updateConfiguration.UpdatePackageUri = ConvertPackageUri(updateConfiguration.UpdatePackageUri);
+                updateConfiguration.UpdatePhpFileUri = ConvertStatisticsUri(updateConfiguration.UpdatePhpFileUri);
+
                 var newPackageSize = GetUpdatePackageSize(updateConfiguration.UpdatePackageUri);
                 if (newPackageSize == null)
                     throw new SizeCalculationException(_lp.PackageSizeCalculationExceptionText);
@@ -276,6 +279,9 @@ namespace nUpdate.Updating
                 double updatePackageSize = 0;
                 foreach (var updateConfiguration in PackageConfigurations)
                 {
+                    updateConfiguration.UpdatePackageUri = ConvertPackageUri(updateConfiguration.UpdatePackageUri);
+                    updateConfiguration.UpdatePhpFileUri = ConvertStatisticsUri(updateConfiguration.UpdatePhpFileUri);
+
                     _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
                     var newPackageSize = GetUpdatePackageSize(updateConfiguration.UpdatePackageUri);
                     if (newPackageSize == null)

--- a/nUpdate.ProvideTAP/Updating/UpdateManager.cs
+++ b/nUpdate.ProvideTAP/Updating/UpdateManager.cs
@@ -218,7 +218,7 @@ namespace nUpdate.Updating
             // Check for SSL and ignore it
             ServicePointManager.ServerCertificateValidationCallback += delegate { return true; };
             var configuration =
-                UpdateConfiguration.Download(UpdateConfigurationFileUri, HttpAuthenticationCredentials, Proxy);
+                UpdateConfiguration.Download(UpdateConfigurationFileUri, HttpAuthenticationCredentials, Proxy, SearchTimeout);
 
             var result = new UpdateResult(configuration, CurrentVersion,
                 IncludeAlpha, IncludeBeta);
@@ -264,7 +264,7 @@ namespace nUpdate.Updating
                 // Check for SSL and ignore it
                 ServicePointManager.ServerCertificateValidationCallback += delegate { return true; };
                 var configuration =
-                    await UpdateConfiguration.DownloadAsync(UpdateConfigurationFileUri, HttpAuthenticationCredentials, Proxy, _searchCancellationTokenSource);
+                    await UpdateConfiguration.DownloadAsync(UpdateConfigurationFileUri, HttpAuthenticationCredentials, Proxy, _searchCancellationTokenSource, SearchTimeout);
 
                 _searchCancellationTokenSource.Token.ThrowIfCancellationRequested();
                 var result = new UpdateResult(configuration, CurrentVersion,

--- a/nUpdate.Shared/Updating/UpdateConfiguration.cs
+++ b/nUpdate.Shared/Updating/UpdateConfiguration.cs
@@ -85,10 +85,11 @@ namespace nUpdate.Updating
         /// </summary>
         /// <param name="configFileUri">The url of the configuration file.</param>
         /// <param name="proxy">The optional proxy to use.</param>
+        /// <param name="timeout">The timeout for the download request. In milliseconds. Default 10000.</param>
         /// <returns>Returns an <see cref="IEnumerable{UpdateConfiguration}" /> containing the package configurations.</returns>
-        public static IEnumerable<UpdateConfiguration> Download(Uri configFileUri, WebProxy proxy)
+        public static IEnumerable<UpdateConfiguration> Download(Uri configFileUri, WebProxy proxy, int timeout = 10000)
         {
-            return Download(configFileUri, null, proxy);
+            return Download(configFileUri, null, proxy, timeout);
         }
 
         /// <summary>
@@ -97,11 +98,12 @@ namespace nUpdate.Updating
         /// <param name="configFileUri">The url of the configuration file.</param>
         /// <param name="credentials">The HTTP authentication credentials.</param>
         /// <param name="proxy">The optional proxy to use.</param>
+        /// <param name="timeout">The timeout for the download request. In milliseconds. Default 10000.</param>
         /// <returns>Returns an <see cref="IEnumerable{UpdateConfiguration}" /> containing the package configurations.</returns>
         public static IEnumerable<UpdateConfiguration> Download(Uri configFileUri, NetworkCredential credentials,
-            WebProxy proxy)
+            WebProxy proxy, int timeout = 10000)
         {
-            using (var wc = new WebClientWrapper(10000))
+            using (var wc = new WebClientWrapper(timeout))
             {
                 wc.Encoding = Encoding.UTF8;
                 if (credentials != null)

--- a/nUpdate.Shared/Updating/UpdateManager.cs
+++ b/nUpdate.Shared/Updating/UpdateManager.cs
@@ -229,6 +229,8 @@ namespace nUpdate.Updating
         /// </remarks>
         public bool UseCustomInstallerUserInterface { get; set; }
 
+        public bool UseDynamicUpdateUri { get; set; } = false;
+
         /// <summary>
         ///     Cancels the download.
         /// </summary>
@@ -271,6 +273,37 @@ namespace nUpdate.Updating
         {
             _packageFilePaths.Clear();
             _packageOperations.Clear();
+        }
+        
+        private Uri ConvertPackageUri(Uri updatePackageUri)
+        {
+            if (!UseDynamicUpdateUri)
+                return updatePackageUri;
+            if (updatePackageUri == null)
+                throw new ArgumentNullException(nameof(updatePackageUri));
+            // The segment of the correct update package URI should include: "/", "1.0.0.0(version)/", "*.zip".
+            if (updatePackageUri.Segments.Length < 3)
+                throw new ArgumentException($"{ nameof(updatePackageUri)} is not a valid update package URI.", nameof(updatePackageUri));
+            var packageNameSegment = updatePackageUri.Segments.Last();
+            var versionSegment = updatePackageUri.Segments[updatePackageUri.Segments.Length - 2];
+            var baseUri = UpdateConfigurationFileUri.GetLeftPart(UriPartial.Authority);
+            var configLocatedPath = string.Join(string.Empty, UpdateConfigurationFileUri.Segments, 0, UpdateConfigurationFileUri.Segments.Length - 1);
+            return new Uri($"{baseUri}{configLocatedPath}{versionSegment}{packageNameSegment}");
+        }
+
+        private Uri ConvertStatisticsUri(Uri statisticsUri)
+        {
+            if (!UseDynamicUpdateUri)
+                return statisticsUri;
+            if (statisticsUri == null)
+                throw new ArgumentNullException(nameof(statisticsUri));
+            // The segment of the correct update php file URI should include: "/", "*.php".
+            if (statisticsUri.Segments.Length < 2)
+                throw new ArgumentException($"{ nameof(statisticsUri)} is not a valid update php file URI.", nameof(statisticsUri));
+            var phpFileName = statisticsUri.Segments.Last();
+            var baseUri = UpdateConfigurationFileUri.GetLeftPart(UriPartial.Authority);
+            var configLocatedPath = string.Join(string.Empty, UpdateConfigurationFileUri.Segments, 0, UpdateConfigurationFileUri.Segments.Length - 1);
+            return new Uri($"{baseUri}{configLocatedPath}{phpFileName}");
         }
 
         /// <summary>

--- a/nUpdate.Shared/Updating/UpdateManager.cs
+++ b/nUpdate.Shared/Updating/UpdateManager.cs
@@ -205,6 +205,12 @@ namespace nUpdate.Updating
         public bool RestartHostApplication { get; set; } = true;
 
         /// <summary>
+        ///     Gets or sets the timeout that should be used when searching for updates. In milliseconds. 
+        ///     By default, this is set to 10000 milliseconds.
+        /// </summary>
+        public int SearchTimeout { get; set; } = 10000;
+
+        /// <summary>
         ///     Gets the total size of all update packages.
         /// </summary>
         public double TotalSize { get; private set; }

--- a/nUpdate.Test/UseDynamicUpdateUriTest.cs
+++ b/nUpdate.Test/UseDynamicUpdateUriTest.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Linq;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using nUpdate.Updating;
+
+namespace nUpdate.Test
+{
+    [TestClass]
+    public class UseDynamicUpdateUriTest
+    {
+        const string PUBLIC_KEY = "<RSAKeyValue><Modulus>xhHXp+QCvWb8+W6TR/hkkhEy9h9WwdAMBMDJbsfn3ObF6U5K2KQCKQ6Alr4iXqlwvcYHKt2CG2M4m9So+rA/N3gg/AETbd74MYXaMRtDqLjkTQuG8EI9JqnlKAR3JS4zWkZghtPsYHtzox7J7Z94iDLAP899r+n9yeafYWwXOsRiTOxKhO9oHHQAK5JlRe9yHMM9F+WanEOGTqfI5FwvldH1Wnahs4xJMhDSB9m92D2zu9nruCmA+7l12hoQOIpsF4hKT6cm4Hm+TcZURForopS4I/lU9W+FDv+GMBrf46+tX2QfmBN9x/NUciyYJvFEAVA1JUXhYT19v+2tW1paASlHhzDGrEFpruWK/NNXPNOlEfdjpZRrvdsRGRYwt5bwt8H7+9n8MAI9ERXO627MIm9wrhvsCuZDDStJNMK05AbOfK/4KwVUUxCn0LO7/aWkhEkljz8fz+cS3lA2yX0Scl8r/z1iRyDjLQJ08bnZJrc3LsVOwQVef1/86IpBBOSkco4g6iaZzgfFSKHNpJvah5Gpa5rt9dq9omcNTANGh5KMNjD7zLM0sXQd3Te1vj5bsWXdBrqFdtWJt627/NTUIEvfKmI4V+hvc3VGnXmBIAPUyodC2pxoDrqWElIXMMgaYl2ifLVQdP7Dw6Z9lZ0CSjW5//Juq/vTANMPBjf6LazWxYto+hTQGjBUYYCaGQKNk3lHkFCBIIMvpGANPjWuLUn0Vbh2PI5KkPElHbJ0CAYRHRG2brNP8Zw95NhaZYMoec3cMLokeU31M1TgkCHeqZspnYlKcGxgQj8xCCPmSwriB1jjGJRBrhC2CK7izrn8Dq7uu0Epg2M8nKeYzhFuiBUashVB/YFUmdA9LALUihv4XN0yXQ4C8UJvsGo+vtpdfWx51smMZxSLcjgfDgnNPR2ZKlJbG7bEowUduZWGurGhRNREC+9E1BZCRylI6c0B+7pgeiOexDzWgQlNnslQWtQs7M1ctsic+8EtOYXd//a4PO1bBhpL9u+FPB+Ek8kSSaGhDUsv0ZkNFdyqKVeP+EmGY5UaQ+b0lCdYmoQjp07Yd3lEb+T7vT/AntBSDcvUITSeP4imgYE7bw5Qo3nWWv3dHz4ubGxrumqQD1I/x7X/QU9SMVfMtcswCLx8inJICaw8jJ5E/mH5lFWY8IOjI5211CkjepKc2wtoeSYxFSVw+896vG3n0dlqerddaBr6kBRSOz5gXS4cucYPXZwiHHaFOqRBdVA84yKn9YNMiVSPdbSIYZk3GEjvQTz9dizOVdQKV0c+HyjrXfXsnwOhMFN8x1iBOD0oeUSMjiV2WidETK117Wnz36lFkUmf7TwOVhaHCI0YC6w9zm9rrcpPWQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>";
+        [TestMethod]
+        public void CanConvertPackageUriWithDomainName()
+        {
+            var literalVersion = "1.0.0.0";
+            var updatePackageUri = new Uri("http://localhost/my-app/nUpdate/1.0.0.0/6b56500f-6557-4808-a68f-6c6fb34fb3e4.zip");
+            var updateManager = new UpdateManager(new Uri("http://www.test.de/nUpdate/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://www.test.de/nUpdate/1.0.0.0/6b56500f-6557-4808-a68f-6c6fb34fb3e4.zip");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertPackageUri", updatePackageUri));
+        }
+
+        [TestMethod]
+        public void CanConvertPackageUriWithDomainNamePort()
+        {
+            var literalVersion = "1.0.0.0";
+            var updatePackageUri = new Uri("http://localhost:8089/nUpdate/my-app/1.0.0.0/6b56500f-6557-4808-a68f-6c6f134fb3e4.zip");
+            var updateManager = new UpdateManager(new Uri("http://www.test.com:8081/my-app/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://www.test.com:8081/my-app/1.0.0.0/6b56500f-6557-4808-a68f-6c6f134fb3e4.zip");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertPackageUri", updatePackageUri));
+        }
+
+        [TestMethod]
+        public void CanConvertPackageUriIp()
+        {
+            var literalVersion = "1.0.0.0";
+            var updatePackageUri = new Uri("http://127.0.0.1/nUpdate/1.0.0.0/6b56500f-6557-4808-a68f-6c6fb32fb3e4.zip");
+            var updateManager = new UpdateManager(new Uri("http://192.168.1.1/nUpdate/my-app/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://192.168.1.1/nUpdate/my-app/1.0.0.0/6b56500f-6557-4808-a68f-6c6fb32fb3e4.zip");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertPackageUri", updatePackageUri));
+        }
+
+        [TestMethod]
+        public void CanConvertPackageUriWithIpPort()
+        {
+            var literalVersion = "1.0.0.0";
+            var updatePackageUri = new Uri("http://127.0.0.1:8089/nUpdate/1.0.0.0/6b56500f-6557-4808-a68f-6c6fb34fb3e4.zip");
+            var updateManager = new UpdateManager(new Uri("http://192.168.1.1:8081/nUpdate/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://192.168.1.1:8081/nUpdate/1.0.0.0/6b56500f-6557-4808-a68f-6c6fb34fb3e4.zip");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertPackageUri", updatePackageUri));
+        }
+
+
+        public void CanConvertStatisticsUriWithDomainName()
+        {
+            var literalVersion = "1.0.0.0";
+            var statisticsUri = new Uri("http://localhost/nUpdate/statistics.php");
+            var updateManager = new UpdateManager(new Uri("http://www.test.de/nUpdate/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://www.test.de/nUpdate/statistics.php");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertStatisticsUri", statisticsUri));
+        }
+
+        [TestMethod]
+        public void CanConvertStatisticsUriWithDomainNamePort()
+        {
+            var literalVersion = "1.0.0.0";
+            var statisticsUri = new Uri("http://localhost:8089/nUpdate/my-app/statistics.php");
+            var updateManager = new UpdateManager(new Uri("http://www.test.com:8081/nUpdate/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://www.test.com:8081/nUpdate/statistics.php");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertStatisticsUri", statisticsUri));
+        }
+
+        [TestMethod]
+        public void CanConvertStatisticsUriWithIp()
+        {
+            var literalVersion = "1.0.0.0";
+            var statisticsUri = new Uri("http://127.0.0.1/updater/nUpdate/statistics.php");
+            var updateManager = new UpdateManager(new Uri("http://192.168.1.1/nUpdate/my-app/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://192.168.1.1/nUpdate/my-app/statistics.php");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertStatisticsUri", statisticsUri));
+        }
+
+        [TestMethod]
+        public void CanConvertStatisticsUriWithIpPort()
+        {
+            var literalVersion = "1.0.0.0";
+            var statisticsUri = new Uri("http://127.0.0.1:8089/nUpdate/statistics.php");
+            var updateManager = new UpdateManager(new Uri("http://192.168.1.1:8081/nUpdate/my-app/updates.json"), PUBLIC_KEY, new System.Globalization.CultureInfo("en"), new UpdateVersion(literalVersion)) { UseDynamicUpdateUri = true };
+            var targetUri = new Uri("http://192.168.1.1:8081/nUpdate/my-app/statistics.php");
+            PrivateObject privateObject = new PrivateObject(updateManager);
+            Assert.AreEqual(targetUri, privateObject.Invoke("ConvertStatisticsUri", statisticsUri));
+        }
+
+    }
+}

--- a/nUpdate.Test/nUpdate.Test.csproj
+++ b/nUpdate.Test/nUpdate.Test.csproj
@@ -52,6 +52,9 @@
       <HintPath>..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net40\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="System" />
     <Reference Include="System.IO, Version=2.6.10.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
@@ -85,6 +88,7 @@
     <Compile Include="UpdateVersionTest.cs" />
     <Compile Include="UriConnectorTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="UseDynamicUpdateUriTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nUpdate.ProvideTAP\nUpdate.ProvideTAP.csproj">

--- a/nUpdate.Test/packages.config
+++ b/nUpdate.Test/packages.config
@@ -3,4 +3,5 @@
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
   <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
   <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
+  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net40" />
 </packages>

--- a/nUpdate.UserInterfaceTest/MainDialog.cs
+++ b/nUpdate.UserInterfaceTest/MainDialog.cs
@@ -19,7 +19,7 @@ namespace nUpdate.UserInterfaceTest
                 PUBLIC_KEY,
                 new CultureInfo("zh-CN"),
                 new UpdateVersion("0.1"))
-            { SearchTimeout = 3000 };
+            { SearchTimeout = 3000, UseDynamicUpdateUri=true };
             // manager.HttpAuthenticationCredentials = new NetworkCredential("trade", "test123");
             _updaterUI = new UpdaterUI(manager, SynchronizationContext.Current);
         }

--- a/nUpdate.UserInterfaceTest/MainDialog.cs
+++ b/nUpdate.UserInterfaceTest/MainDialog.cs
@@ -8,14 +8,18 @@ namespace nUpdate.UserInterfaceTest
 {
     public partial class MainDialog : Form
     {
+        const string PUBLIC_KEY = "<RSAKeyValue><Modulus>xhHXp+QCvWb8+W6TR/hkkhEy9h9WwdAMBMDJbsfn3ObF6U5K2KQCKQ6Alr4iXqlwvcYHKt2CG2M4m9So+rA/N3gg/AETbd74MYXaMRtDqLjkTQuG8EI9JqnlKAR3JS4zWkZghtPsYHtzox7J7Z94iDLAP899r+n9yeafYWwXOsRiTOxKhO9oHHQAK5JlRe9yHMM9F+WanEOGTqfI5FwvldH1Wnahs4xJMhDSB9m92D2zu9nruCmA+7l12hoQOIpsF4hKT6cm4Hm+TcZURForopS4I/lU9W+FDv+GMBrf46+tX2QfmBN9x/NUciyYJvFEAVA1JUXhYT19v+2tW1paASlHhzDGrEFpruWK/NNXPNOlEfdjpZRrvdsRGRYwt5bwt8H7+9n8MAI9ERXO627MIm9wrhvsCuZDDStJNMK05AbOfK/4KwVUUxCn0LO7/aWkhEkljz8fz+cS3lA2yX0Scl8r/z1iRyDjLQJ08bnZJrc3LsVOwQVef1/86IpBBOSkco4g6iaZzgfFSKHNpJvah5Gpa5rt9dq9omcNTANGh5KMNjD7zLM0sXQd3Te1vj5bsWXdBrqFdtWJt627/NTUIEvfKmI4V+hvc3VGnXmBIAPUyodC2pxoDrqWElIXMMgaYl2ifLVQdP7Dw6Z9lZ0CSjW5//Juq/vTANMPBjf6LazWxYto+hTQGjBUYYCaGQKNk3lHkFCBIIMvpGANPjWuLUn0Vbh2PI5KkPElHbJ0CAYRHRG2brNP8Zw95NhaZYMoec3cMLokeU31M1TgkCHeqZspnYlKcGxgQj8xCCPmSwriB1jjGJRBrhC2CK7izrn8Dq7uu0Epg2M8nKeYzhFuiBUashVB/YFUmdA9LALUihv4XN0yXQ4C8UJvsGo+vtpdfWx51smMZxSLcjgfDgnNPR2ZKlJbG7bEowUduZWGurGhRNREC+9E1BZCRylI6c0B+7pgeiOexDzWgQlNnslQWtQs7M1ctsic+8EtOYXd//a4PO1bBhpL9u+FPB+Ek8kSSaGhDUsv0ZkNFdyqKVeP+EmGY5UaQ+b0lCdYmoQjp07Yd3lEb+T7vT/AntBSDcvUITSeP4imgYE7bw5Qo3nWWv3dHz4ubGxrumqQD1I/x7X/QU9SMVfMtcswCLx8inJICaw8jJ5E/mH5lFWY8IOjI5211CkjepKc2wtoeSYxFSVw+896vG3n0dlqerddaBr6kBRSOz5gXS4cucYPXZwiHHaFOqRBdVA84yKn9YNMiVSPdbSIYZk3GEjvQTz9dizOVdQKV0c+HyjrXfXsnwOhMFN8x1iBOD0oeUSMjiV2WidETK117Wnz36lFkUmf7TwOVhaHCI0YC6w9zm9rrcpPWQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>";
         private readonly UpdaterUI _updaterUI;
 
         public MainDialog()
         {
             InitializeComponent();
-            var manager = new UpdateManager(new Uri("https://www.nupdate.net/test/updates.json"),
-                "<RSAKeyValue><Modulus>xhHXp+QCvWb8+W6TR/hkkhEy9h9WwdAMBMDJbsfn3ObF6U5K2KQCKQ6Alr4iXqlwvcYHKt2CG2M4m9So+rA/N3gg/AETbd74MYXaMRtDqLjkTQuG8EI9JqnlKAR3JS4zWkZghtPsYHtzox7J7Z94iDLAP899r+n9yeafYWwXOsRiTOxKhO9oHHQAK5JlRe9yHMM9F+WanEOGTqfI5FwvldH1Wnahs4xJMhDSB9m92D2zu9nruCmA+7l12hoQOIpsF4hKT6cm4Hm+TcZURForopS4I/lU9W+FDv+GMBrf46+tX2QfmBN9x/NUciyYJvFEAVA1JUXhYT19v+2tW1paASlHhzDGrEFpruWK/NNXPNOlEfdjpZRrvdsRGRYwt5bwt8H7+9n8MAI9ERXO627MIm9wrhvsCuZDDStJNMK05AbOfK/4KwVUUxCn0LO7/aWkhEkljz8fz+cS3lA2yX0Scl8r/z1iRyDjLQJ08bnZJrc3LsVOwQVef1/86IpBBOSkco4g6iaZzgfFSKHNpJvah5Gpa5rt9dq9omcNTANGh5KMNjD7zLM0sXQd3Te1vj5bsWXdBrqFdtWJt627/NTUIEvfKmI4V+hvc3VGnXmBIAPUyodC2pxoDrqWElIXMMgaYl2ifLVQdP7Dw6Z9lZ0CSjW5//Juq/vTANMPBjf6LazWxYto+hTQGjBUYYCaGQKNk3lHkFCBIIMvpGANPjWuLUn0Vbh2PI5KkPElHbJ0CAYRHRG2brNP8Zw95NhaZYMoec3cMLokeU31M1TgkCHeqZspnYlKcGxgQj8xCCPmSwriB1jjGJRBrhC2CK7izrn8Dq7uu0Epg2M8nKeYzhFuiBUashVB/YFUmdA9LALUihv4XN0yXQ4C8UJvsGo+vtpdfWx51smMZxSLcjgfDgnNPR2ZKlJbG7bEowUduZWGurGhRNREC+9E1BZCRylI6c0B+7pgeiOexDzWgQlNnslQWtQs7M1ctsic+8EtOYXd//a4PO1bBhpL9u+FPB+Ek8kSSaGhDUsv0ZkNFdyqKVeP+EmGY5UaQ+b0lCdYmoQjp07Yd3lEb+T7vT/AntBSDcvUITSeP4imgYE7bw5Qo3nWWv3dHz4ubGxrumqQD1I/x7X/QU9SMVfMtcswCLx8inJICaw8jJ5E/mH5lFWY8IOjI5211CkjepKc2wtoeSYxFSVw+896vG3n0dlqerddaBr6kBRSOz5gXS4cucYPXZwiHHaFOqRBdVA84yKn9YNMiVSPdbSIYZk3GEjvQTz9dizOVdQKV0c+HyjrXfXsnwOhMFN8x1iBOD0oeUSMjiV2WidETK117Wnz36lFkUmf7TwOVhaHCI0YC6w9zm9rrcpPWQ==</Modulus><Exponent>AQAB</Exponent></RSAKeyValue>",
-                new CultureInfo("de-DE"), new UpdateVersion("0.1"));
+
+            var manager = new UpdateManager(new Uri("http://localhost:1010/Target-Updater/updates.json"),
+                PUBLIC_KEY,
+                new CultureInfo("zh-CN"),
+                new UpdateVersion("0.1"))
+            { SearchTimeout = 3000 };
             // manager.HttpAuthenticationCredentials = new NetworkCredential("trade", "test123");
             _updaterUI = new UpdaterUI(manager, SynchronizationContext.Current);
         }

--- a/nUpdate.WithoutTAP/Updating/UpdateConfiguration.cs
+++ b/nUpdate.WithoutTAP/Updating/UpdateConfiguration.cs
@@ -18,10 +18,11 @@ namespace nUpdate.Updating
         /// <param name="proxy">The optional proxy to use.</param>
         /// <param name="finishedCallback">The <see cref="Action"/> to invoke when the operation has finished.</param>
         /// <param name="cancellationTokenSource">The optional <see cref="CancellationTokenSource"/> to use for canceling the operation.</param>
+        /// <param name="timeout">The timeout for the download request. In milliseconds. Default 10000.</param>
         /// <returns>Returns an <see cref="IEnumerable{UpdateConfiguration}" /> containing the package configurations.</returns>
-        public static void DownloadAsync(Uri configFileUri, WebProxy proxy, Action<IEnumerable<UpdateConfiguration>, Exception> finishedCallback, CancellationTokenSource cancellationTokenSource = null)
+        public static void DownloadAsync(Uri configFileUri, WebProxy proxy, Action<IEnumerable<UpdateConfiguration>, Exception> finishedCallback, CancellationTokenSource cancellationTokenSource = null, int timeout = 10000)
         {
-            DownloadAsync(configFileUri, null, proxy, finishedCallback, cancellationTokenSource);
+            DownloadAsync(configFileUri, null, proxy, finishedCallback, cancellationTokenSource, timeout);
         }
 
         /// <summary>
@@ -32,11 +33,12 @@ namespace nUpdate.Updating
         /// <param name="proxy">The optional proxy to use.</param>
         /// <param name="finishedCallback">The <see cref="Action"/> to invoke when the operation has finished.</param>
         /// <param name="cancellationTokenSource">The optional <see cref="CancellationTokenSource"/> to use for canceling the operation.</param>
+        /// <param name="timeout">The timeout for the download request. In milliseconds. Default 10000.</param>
         /// <returns>Returns an <see cref="IEnumerable{UpdateConfiguration}" /> containing the package configurations.</returns>
         public static void DownloadAsync(Uri configFileUri, NetworkCredential credentials,
-            WebProxy proxy, Action<IEnumerable<UpdateConfiguration>, Exception> finishedCallback, CancellationTokenSource cancellationTokenSource = null)
+            WebProxy proxy, Action<IEnumerable<UpdateConfiguration>, Exception> finishedCallback, CancellationTokenSource cancellationTokenSource = null, int timeout = 10000)
         {
-            using (var wc = new WebClientWrapper(10000))
+            using (var wc = new WebClientWrapper(timeout))
             {
                 var resetEvent = new ManualResetEvent(false);
                 string source = null;

--- a/nUpdate.WithoutTAP/Updating/UpdateManager.cs
+++ b/nUpdate.WithoutTAP/Updating/UpdateManager.cs
@@ -297,7 +297,7 @@ namespace nUpdate.Updating
             // Check for SSL and ignore it
             ServicePointManager.ServerCertificateValidationCallback += delegate { return true; };
             var configuration =
-                UpdateConfiguration.Download(UpdateConfigurationFileUri, HttpAuthenticationCredentials, Proxy);
+                UpdateConfiguration.Download(UpdateConfigurationFileUri, HttpAuthenticationCredentials, Proxy, SearchTimeout);
 
             var result = new UpdateResult(configuration, CurrentVersion,
                 IncludeAlpha, IncludeBeta);
@@ -354,7 +354,7 @@ namespace nUpdate.Updating
                         configurations = c;
                         exception = e;
                         _searchManualResetEvent.Set();
-                    }, _searchCancellationTokenSource);
+                    }, _searchCancellationTokenSource, SearchTimeout);
                 _searchManualResetEvent.WaitOne();
 
                 // Check for cancellation before throwing any errors

--- a/nUpdate.WithoutTAP/Updating/UpdateManager.cs
+++ b/nUpdate.WithoutTAP/Updating/UpdateManager.cs
@@ -308,6 +308,9 @@ namespace nUpdate.Updating
             double updatePackageSize = 0;
             foreach (var updateConfiguration in PackageConfigurations)
             {
+                updateConfiguration.UpdatePackageUri = ConvertPackageUri(updateConfiguration.UpdatePackageUri);
+                updateConfiguration.UpdatePhpFileUri = ConvertStatisticsUri(updateConfiguration.UpdatePhpFileUri);
+
                 var newPackageSize = GetUpdatePackageSize(updateConfiguration.UpdatePackageUri);
                 if (newPackageSize == null)
                     throw new SizeCalculationException(_lp.PackageSizeCalculationExceptionText);
@@ -372,6 +375,9 @@ namespace nUpdate.Updating
                 double updatePackageSize = 0;
                 foreach (var updateConfiguration in PackageConfigurations)
                 {
+                    updateConfiguration.UpdatePackageUri = ConvertPackageUri(updateConfiguration.UpdatePackageUri);
+                    updateConfiguration.UpdatePhpFileUri = ConvertStatisticsUri(updateConfiguration.UpdatePhpFileUri);
+
                     if (_searchCancellationTokenSource.IsCancellationRequested)
                         return false;
 


### PR DESCRIPTION
# Fixed #48 and add two properties for UpdateManager

- ## BUG

    - Fixed #48 and another same bug

        There is an improper use of accessing UI controls in non-UI threads in the "InitializeData" method of the "ProjectEditDialog" class.

        The original code: The "Popup.ShowPopup" method is called without "Invoke" in the "Task.Factory.StartNew method", and it is like this:

        ```C#
            private async void InitializeData()
            {
                await Task.Factory.StartNew(() =>
                {
                    ...
                    bool synchronizeData = Popup.ShowPopup(this, SystemIcons.Question, "Automatically synchronize data?",
                        "nUpdate Administration may encounter differences between your remote configuration and the local changes that you've made. Should nUpdate Administration try to synchronize these changes or do you want to keep them locally? Choose the latter option, if you just fixed a problem with the data (e.g. a typo due to which nUpdate Administration could not connect to the server).",
                        PopupButtons.YesNo) == DialogResult.Yes;
                    ...
                    if (Project.Path != _localPath)
                    {
                        if (Popup.ShowPopup(this, SystemIcons.Question, "Automatically move the project file?",
                            "nUpdate Administration noticed that the path of the local project file has changed. Should nUpdate Administration move it to this new location? Choose \"No\", if the file is already located at the path that you specified.",
                            PopupButtons.YesNo) == DialogResult.Yes)
                        {
                            ...
                        }
                        ...
                    }
                    ...
                }
            }
        ```

        P.S. Although the BUG does not always occur, but I still think it is better to fix it.

- ## Add

    - Add "SearchTimeout" property for "UpdateManager"

        This property gets or sets the timeout that should be used when searching for updates. By default, this is set to 10000 milliseconds.

    - Add "UseDynamicUpdateUri" property for "UpdateManager"

        - Description

            The proerty indicating whether the nUpdate set every update package URI (its parent directory) is automatically to the one that corresponds to the directory where also the configuration file is located before downloading update package. Default false.

            `UpdateConfigurationFileUri` is 'http://www.test.de/nNpdate/updates.json', version is '1.0.0.0', `UpdatePackageUri` is 'http://localhost/nNpdate/1.0.0.0/id.zip',  the nUpdate will download the update-packages from 'http://www.test.de/nNpdate/1.0.0.0/id.zip' instead of 'http://localhost/nNpdate/1.0.0.0/id.zip'.

        - Why add?

            When updating the same software in multiple networks that do not communicate, the user only need to create one nUpdate project to manage the upgrade package and then distribute the upgrade package to the servers in each network. Without this property, the user will need to create multiple nUpdate projects, or re-edit the nUpdate project or modify the `UpdatePackageUri` value of each `updates.json` before distribute the upgrade package to each server.

        - Use scene case of `UseDynamicUpdateUri`.

            One APP：APP-A. Multiple non communication LAN: LAN-1, LAN-2, ... LAN-N.

            LAN-1 Server IP：192.168.0.1.

            LAN-2 Server IP：192.168.2.1.

            ...

            LAN-N Server IP：192.168.N.1.

            When deploying APP-A's update-package for LAN-1, the user needs to create an nUpdate project and add an upgrade packages, and the. After completing the above operation, `updates.json` should be similar to the following.

            ``` json
            [
                {
                    "Architecture": 2,
                    "Changelog": {
                        "en": "..."
                    },
                    "LiteralVersion": "1.0.1.0",
                    "NecessaryUpdate": false,
                    "Operations": [],
                    "Signature": "sigin",
                    "UnsupportedVersions": null,
                    "UpdatePackageUri": "http://192.168.0.1/updater/1.0.1.0/6ab6501f-6557-4808-a68f-6c6fb34fb3e4.zip",
                    "UpdatePhpFileUri": "http://192.168.0.1/updater/statistics.php",
                    "UseStatistics": false,
                    "VersionId": 12
                }
            ]
            ```

            Now the user also needs to deploy APP-A's update-package for LAN-2. Since the server-IP of LAN-1 and LAN-2 are not the same, users cannot directly use `update.json` and upgrade packages in LAN-1. At this time, the user needs to re-edit the nUpdate project previously created or modify the `UpdatePackageUri` of `updates.json` or create a new nUpdate project for LAN-2. But I think these three methods are not convenient, so I added this property. This scene also applies to LAN-N.

            Another similar scenario is that the provider of the update package is not in the same network as the software user.